### PR TITLE
Clean up install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,7 @@ configure
 set system package repository blacklist components main
 set system package repository blacklist description 'Britannic blacklist debian wheezy repository'
 set system package repository blacklist distribution wheezy
-set system package repository blacklist password ''
 set system package repository blacklist url 'https://raw.githubusercontent.com/britannic/debian-repo/master/blacklist/'
-set system package repository blacklist username ''
 commit;save;exit
 ```
 


### PR DESCRIPTION
The empty username and password are implicit, this makes the documentation a little tidier